### PR TITLE
update ws to 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "dependencies": {
     "express": "^4.13.1",
     "mustache": "^2.1.3",
-    "ws": "^0.7.2"
+    "ws": "^0.8.0"
   }
 }


### PR DESCRIPTION
the ws 0.7.x versions do not compile under node 4.x, whereas the 0.8.x version does